### PR TITLE
Remove WEBKIT_DISABLE_COMPOSITING_MODE from tauri script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "tauri": "WEBKIT_DISABLE_COMPOSITING_MODE=1 tauri",
+    "tauri": "tauri",
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",


### PR DESCRIPTION
chore: The tauri script in package.json no longer sets the WEBKIT_DISABLE_COMPOSITING_MODE environment variable. This simplifies the script and may resolve issues related to compositing mode.